### PR TITLE
fixing arg nesting and allowed ip config generation

### DIFF
--- a/app/views/admin/vpn_configurations.html.erb
+++ b/app/views/admin/vpn_configurations.html.erb
@@ -140,7 +140,7 @@
       <div class="row g-2 align-items-end">
         <div class="col-md-8">
           <label class="form-label" for="network_address">Network Address (CIDR format)</label>
-          <%= form.text_field :network_address, id: "network_address", class: "form-control", placeholder: "X.X.X.X/YY" %>
+          <%= text_field_tag :network_address, nil, id: "network_address", class: "form-control", placeholder: "X.X.X.X/YY" %>
         </div>
         <div class="col-md-4">
           <%= form.submit "Add Network Address", class: "btn btn-primary w-100", data: { turbo_confirm: "Adding a network address may require client reconfiguration. Continue?" } %>

--- a/lib/wireguard_config_generator.rb
+++ b/lib/wireguard_config_generator.rb
@@ -35,10 +35,13 @@ class WireguardConfigGenerator
       # Use wg_fqdn if available, otherwise fall back to wg_ip_address
       endpoint = vpn_configuration.wg_fqdn.present? ? vpn_configuration.wg_fqdn : vpn_configuration.wg_ip_address
       config += "Endpoint = #{endpoint}:#{vpn_configuration.wg_port}\n"
-      config += "AllowedIPs = #{vpn_subnet(vpn_configuration)}\n"
+      allowed_ips = []
+      allowed_ips << "#{vpn_configuration.server_vpn_ip_address}/32"
+
       vpn_configuration.network_addresses.each do |ip_address|
-        config += "AllowedIPs = #{ip_address.network_address}\n"
+        allowed_ips << ip_address.network_address
       end
+      config += "AllowedIPs = #{allowed_ips.join(', ')}\n"
       config += "PersistentKeepalive = 20\n" if vpn_configuration.wg_keep_alive.present?
       config += "\n"
 


### PR DESCRIPTION
## Issues
* Network address is getting saved in this format `{"network_address" => "10.42.5.0/24"}` - fix :: we want 10.42.5.0/24
* Network addresses are coming up in new AllowedIPs - fix :: we want single AllowedIPs with comma separated network adderesses